### PR TITLE
feat: phase 9 UI polish

### DIFF
--- a/docs/handoff/phase-9-handoff.md
+++ b/docs/handoff/phase-9-handoff.md
@@ -1,0 +1,45 @@
+---
+phase: 9
+status: complete
+date: 2025-09-01
+branch: feat/phase-9-ui-polish
+commit: 2afe947
+next_phase: 10
+artifacts:
+  frontend:
+    routes:
+      - /dashboard
+      - /trips
+      - /clients
+links:
+  dashboard: "http://localhost:5173/dashboard"
+  trips: "http://localhost:5173/trips"
+  clients: "http://localhost:5173/clients"
+---
+# Phase 9 Handoff — Design Polish & Navigation
+
+## 1) What shipped
+- Persistent navbar with live WebSocket indicator and mobile menu.
+- Grid-based layout with titles, breadcrumbs and responsive design.
+- Trip filters for destination and date range.
+- Client search with instant filtering.
+- Toast notifications and realtime status indicator.
+- Skeleton loaders and friendly empty states.
+
+## 2) How to run
+```bash
+docker compose up -d --build
+docker compose exec web python manage.py migrate
+docker compose exec web python manage.py loaddata seeds/phase1.json
+npm --prefix frontend install
+npm --prefix frontend run dev
+```
+
+## 3) API surface (current)
+### Endpoints
+- GET /api/trips/ (destination, date_from, date_to)
+- GET /api/clients/?search=
+
+## Screenshots
+![Navbar](../screenshots/phase-9/navbar.png)
+![Trips filters](../screenshots/phase-9/trips-filters.png)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,11 +7,14 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "@headlessui/react": "^2.2.0",
+    "@heroicons/react": "^2.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -24,6 +27,10 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/user-event": "^14.5.1"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,8 @@ import ClientProfile from './pages/ClientProfile';
 import TripsList from './pages/TripsList';
 import TripDetail from './pages/TripDetail';
 import Dashboard from './pages/Dashboard';
-import Navbar from './components/Navbar';
 import ActivityFeed from './pages/ActivityFeed';
+import { WebSocketProvider } from './components/WebSocketProvider';
 
 function App() {
   const path = window.location.pathname;
@@ -24,12 +24,7 @@ function App() {
   } else {
     page = <Dashboard />;
   }
-  return (
-    <div>
-      <Navbar />
-      {page}
-    </div>
-  );
+  return <WebSocketProvider>{page}</WebSocketProvider>;
 }
 
 export default App;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import Toasts from './Toasts';
+import Navbar from './Navbar';
+
+interface Crumb {
+  label: string;
+  href?: string;
+}
+
+export default function Layout({ title, breadcrumbs = [], children }: { title: string; breadcrumbs?: Crumb[]; children: ReactNode }) {
+  return (
+    <div className="min-h-screen grid grid-rows-[auto,1fr]">
+      <Navbar />
+      <main className="p-4 max-w-7xl mx-auto w-full space-y-4">
+        {breadcrumbs.length > 0 && (
+          <nav className="text-sm text-gray-500">
+            {breadcrumbs.map((bc, i) => (
+              <span key={i}>
+                {bc.href ? (
+                  <a className="hover:underline" href={bc.href}>
+                    {bc.label}
+                  </a>
+                ) : (
+                  <span>{bc.label}</span>
+                )}
+                {i < breadcrumbs.length - 1 && ' / '}
+              </span>
+            ))}
+          </nav>
+        )}
+        <h1 className="text-2xl font-bold">{title}</h1>
+        {children}
+      </main>
+      <Toasts />
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Navbar from './Navbar';
+import { WebSocketProvider } from './WebSocketProvider';
+
+describe('Navbar', () => {
+  it('renders links', () => {
+    render(
+      <WebSocketProvider>
+        <Navbar />
+      </WebSocketProvider>
+    );
+    expect(screen.getByText('Dashboard').getAttribute('href')).toBe('/dashboard');
+    expect(screen.getByText('Trips').getAttribute('href')).toBe('/trips');
+    expect(screen.getByText('Clients').getAttribute('href')).toBe('/clients');
+  });
+});

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,10 +1,45 @@
+import { Disclosure } from '@headlessui/react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useWebSocket } from './WebSocketProvider';
+
+const links = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/trips', label: 'Trips' },
+  { href: '/clients', label: 'Clients' },
+];
+
 export default function Navbar() {
+  const { connected } = useWebSocket();
   return (
-    <nav className="bg-primary text-white p-4 flex flex-col sm:flex-row gap-4">
-      <a href="/dashboard" className="font-semibold">Dashboard</a>
-      <a href="/clients" className="font-semibold">Clients</a>
-      <a href="/trips" className="font-semibold">Trips</a>
-      <a href="/activity" className="font-semibold">Activity</a>
-    </nav>
+    <Disclosure as="nav" className="bg-primary text-white">
+      {({ open }) => (
+        <>
+          <div className="mx-auto max-w-7xl px-4">
+            <div className="flex h-16 items-center justify-between">
+              <div className="flex items-center">
+                <Disclosure.Button className="sm:hidden inline-flex items-center justify-center rounded-md p-2">
+                  {open ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+                </Disclosure.Button>
+                <div className="hidden sm:flex sm:space-x-4">
+                  {links.map((l) => (
+                    <a key={l.href} href={l.href} className="px-3 py-2 font-semibold">
+                      {l.label}
+                    </a>
+                  ))}
+                </div>
+              </div>
+              <span className={`h-3 w-3 rounded-full ${connected ? 'bg-success' : 'bg-gray-300'}`}></span>
+            </div>
+          </div>
+          <Disclosure.Panel className="sm:hidden px-2 pb-3 space-y-1">
+            {links.map((l) => (
+              <a key={l.href} href={l.href} className="block px-3 py-2 font-semibold">
+                {l.label}
+              </a>
+            ))}
+          </Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
   );
 }

--- a/frontend/src/components/Toasts.tsx
+++ b/frontend/src/components/Toasts.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useWebSocket } from './WebSocketProvider';
+
+function Toast({ id, message }: { id: number; message: string }) {
+  const { dismiss } = useWebSocket();
+  useEffect(() => {
+    const timer = setTimeout(() => dismiss(id), 3000);
+    return () => clearTimeout(timer);
+  }, [id, dismiss]);
+  return (
+    <div className="bg-primary text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+}
+
+export default function Toasts() {
+  const { toasts } = useWebSocket();
+  return (
+    <div className="fixed top-4 right-4 space-y-2 z-50">
+      {toasts.map((t) => (
+        <Toast key={t.id} id={t.id} message={t.message} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/WebSocketProvider.tsx
+++ b/frontend/src/components/WebSocketProvider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+interface WSContext {
+  connected: boolean;
+  toasts: Toast[];
+  dismiss: (id: number) => void;
+}
+
+const WebSocketContext = createContext<WSContext>({ connected: false, toasts: [], dismiss: () => {} });
+
+export function WebSocketProvider({ children }: { children: React.ReactNode }) {
+  const [connected, setConnected] = useState(false);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:8000/ws/dashboard/');
+    ws.onopen = () => setConnected(true);
+    ws.onclose = () => setConnected(false);
+    ws.onmessage = (e) => {
+      const msg = typeof e.data === 'string' ? e.data : '';
+      setToasts((t) => [...t, { id: Date.now(), message: msg }]);
+      window.dispatchEvent(new CustomEvent('ws-message', { detail: msg }));
+    };
+    return () => ws.close();
+  }, []);
+
+  const dismiss = (id: number) => setToasts((t) => t.filter((toast) => toast.id !== id));
+
+  return (
+    <WebSocketContext.Provider value={{ connected, toasts, dismiss }}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useWebSocket() {
+  return useContext(WebSocketContext);
+}

--- a/frontend/src/pages/ActivityFeed.tsx
+++ b/frontend/src/pages/ActivityFeed.tsx
@@ -5,7 +5,7 @@ type Event = {
   id: string;
   type: string;
   client_id: string | null;
-  data: any;
+  data: unknown;
   created_at: string;
 };
 

--- a/frontend/src/pages/ClientProfile.tsx
+++ b/frontend/src/pages/ClientProfile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
+import Layout from "../components/Layout";
 
 type Phone = { e164: string; label: string };
 type Client = {
@@ -95,147 +96,144 @@ export default function ClientProfile({ id }: { id: string }) {
   }, [id]);
 
   useEffect(() => {
-    const ws = new WebSocket("ws://localhost:8000/ws/clients/");
-    ws.onmessage = (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        if (data.type === "client.updated" && data.client_id === id) {
-          fetchClient();
-          fetchHistory();
-        }
-        if (
-          data.type === "reservation.updated" &&
-          data.client_ids?.includes(id)
-        ) {
-          fetchHistory();
-        }
-        if (data.type === "client.tagged" && data.client_id === id) {
-          fetchClient();
-        }
-        if (data.type === "client.note.added" && data.client_id === id) {
-          fetchNotes();
-        }
-      } catch (err) {
-        console.error(err);
-      }
+    const handler = () => {
+      fetchClient();
+      fetchHistory();
+      fetchNotes();
     };
-    return () => ws.close();
+    window.addEventListener('ws-message', handler);
+    return () => window.removeEventListener('ws-message', handler);
   }, [id]);
 
-  if (!client) return <div className="p-4">Loading...</div>;
+  if (!client)
+    return (
+      <Layout title="Client">
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-200 animate-pulse"></div>
+          ))}
+        </div>
+      </Layout>
+    );
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">
-        {client.first_name} {client.last_name}
-      </h1>
-      <div className="flex gap-4 border-b">
-        <button
-          className={`p-2 ${tab === "profile" ? "border-b-2" : ""}`}
-          onClick={() => setTab("profile")}
-        >
-          Profile
-        </button>
-        <button
-          className={`p-2 ${tab === "history" ? "border-b-2" : ""}`}
-          onClick={() => setTab("history")}
-        >
-          History
-        </button>
-      </div>
-      {tab === "profile" ? (
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <p>Email: {client.email}</p>
-            <p>Passport: {client.passport_id}</p>
-            <p>Phones: {client.phones?.map((p) => p.e164).join(", ")}</p>
+    <Layout
+      title={`${client.first_name} ${client.last_name}`}
+      breadcrumbs={[
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Clients', href: '/clients' },
+        { label: `${client.first_name} ${client.last_name}` },
+      ]}
+    >
+      <div className="space-y-4">
+          <div className="flex gap-4 border-b">
+            <button
+              className={`p-2 ${tab === "profile" ? "border-b-2" : ""}`}
+              onClick={() => setTab("profile")}
+            >
+              Profile
+            </button>
+            <button
+              className={`p-2 ${tab === "history" ? "border-b-2" : ""}`}
+              onClick={() => setTab("history")}
+            >
+              History
+            </button>
           </div>
-          <div>
-            <h2 className="text-xl font-semibold">Tags</h2>
-            <div className="flex flex-wrap gap-2">
-              {client.tags?.map((t) => (
-                <span key={t} className="bg-gray-200 px-2 rounded">
-                  {t} <button onClick={() => removeTag(t)}>x</button>
-                </span>
-              ))}
+          {tab === "profile" ? (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <p>Email: {client.email}</p>
+                <p>Passport: {client.passport_id}</p>
+                <p>Phones: {client.phones?.map((p) => p.e164).join(", ")}</p>
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold">Tags</h2>
+                <div className="flex flex-wrap gap-2">
+                  {client.tags?.map((t) => (
+                    <span key={t} className="bg-gray-200 px-2 rounded">
+                      {t} <button onClick={() => removeTag(t)}>x</button>
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-2">
+                  <input
+                    value={newTag}
+                    onChange={(e) => setNewTag(e.target.value)}
+                    className="border px-2"
+                  />
+                  <button
+                    className="ml-2 px-2 bg-primary text-white"
+                    onClick={addTag}
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold">Notes</h2>
+                <ul className="list-disc pl-5">
+                  {notes.map((n) => (
+                    <li key={n.id}>
+                      <b>{n.author}</b>: {n.text}
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-2 flex gap-2">
+                  <input
+                    placeholder="Author"
+                    value={noteAuthor}
+                    onChange={(e) => setNoteAuthor(e.target.value)}
+                    className="border px-2"
+                  />
+                  <input
+                    placeholder="Note"
+                    value={noteText}
+                    onChange={(e) => setNoteText(e.target.value)}
+                    className="border px-2 flex-1"
+                  />
+                  <button className="px-2 bg-primary text-white" onClick={addNote}>
+                    Add
+                  </button>
+                </div>
+              </div>
+              <div>
+                <h2 className="text-xl font-semibold">Reservations</h2>
+                <ul className="list-disc pl-5">
+                  {reservations.map((r) => (
+                    <li key={r.id}>
+                      {r.trip} — {r.status} ({r.quantity})
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
-            <div className="mt-2">
-              <input
-                value={newTag}
-                onChange={(e) => setNewTag(e.target.value)}
-                className="border px-2"
-              />
-              <button
-                className="ml-2 px-2 bg-primary text-white"
-                onClick={addTag}
-              >
-                Add
-              </button>
+          ) : (
+            <div>
+              <h2 className="text-xl font-semibold">Trip History</h2>
+              <table className="min-w-full text-left border">
+                <thead>
+                  <tr>
+                    <th className="px-2">Date</th>
+                    <th className="px-2">Destination</th>
+                    <th className="px-2">Seat</th>
+                    <th className="px-2">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {history.map((h) => (
+                    <tr key={`${h.reservation_id}-${h.seat_no}`}>
+                      <td className="px-2">{h.date}</td>
+                      <td className="px-2">{h.destination}</td>
+                      <td className="px-2">{h.seat_no ?? "-"}</td>
+                      <td className="px-2">{h.status}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          </div>
-          <div>
-            <h2 className="text-xl font-semibold">Notes</h2>
-            <ul className="list-disc pl-5">
-              {notes.map((n) => (
-                <li key={n.id}>
-                  <b>{n.author}</b>: {n.text}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-2 flex gap-2">
-              <input
-                placeholder="Author"
-                value={noteAuthor}
-                onChange={(e) => setNoteAuthor(e.target.value)}
-                className="border px-2"
-              />
-              <input
-                placeholder="Note"
-                value={noteText}
-                onChange={(e) => setNoteText(e.target.value)}
-                className="border px-2 flex-1"
-              />
-              <button className="px-2 bg-primary text-white" onClick={addNote}>
-                Add
-              </button>
-            </div>
-          </div>
-          <div>
-            <h2 className="text-xl font-semibold">Reservations</h2>
-            <ul className="list-disc pl-5">
-              {reservations.map((r) => (
-                <li key={r.id}>
-                  {r.trip} — {r.status} ({r.quantity})
-                </li>
-              ))}
-            </ul>
-          </div>
+          )}
         </div>
-      ) : (
-        <div>
-          <h2 className="text-xl font-semibold">Trip History</h2>
-          <table className="min-w-full text-left border">
-            <thead>
-              <tr>
-                <th className="px-2">Date</th>
-                <th className="px-2">Destination</th>
-                <th className="px-2">Seat</th>
-                <th className="px-2">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {history.map((h) => (
-                <tr key={`${h.reservation_id}-${h.seat_no}`}>
-                  <td className="px-2">{h.date}</td>
-                  <td className="px-2">{h.destination}</td>
-                  <td className="px-2">{h.seat_no ?? "-"}</td>
-                  <td className="px-2">{h.status}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  );
+      </Layout>
+    );
 }

--- a/frontend/src/pages/ClientsList.test.tsx
+++ b/frontend/src/pages/ClientsList.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../api', () => ({ api: vi.fn(() => Promise.resolve([])) }));
+import ClientsList from './ClientsList';
+
+describe('ClientsList states', () => {
+  it('shows empty state', async () => {
+    render(<ClientsList />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText('No clients found.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ClientsList.tsx
+++ b/frontend/src/pages/ClientsList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import Layout from '../components/Layout';
 
 type Client = {
   id: string;
@@ -11,11 +12,14 @@ type Client = {
 export default function ClientsList() {
   const [search, setSearch] = useState('');
   const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(false);
 
   const fetchClients = () => {
+    setLoading(true);
     api<Client[]>(`/api/clients/?search=${encodeURIComponent(search)}`)
       .then(setClients)
-      .catch(() => setClients([]));
+      .catch(() => setClients([]))
+      .finally(() => setLoading(false));
   };
 
   useEffect(() => {
@@ -23,14 +27,13 @@ export default function ClientsList() {
   }, [search]);
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8000/ws/dashboard/');
-    ws.onmessage = fetchClients;
-    return () => ws.close();
+    const handler = () => fetchClients();
+    window.addEventListener('ws-message', handler);
+    return () => window.removeEventListener('ws-message', handler);
   }, [search]);
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Clients</h1>
+    <Layout title="Clients" breadcrumbs={[{ label: 'Dashboard', href: '/dashboard' }, { label: 'Clients' }]}>
       <div className="flex flex-col md:flex-row gap-2">
         <input
           className="border p-2 flex-1"
@@ -38,29 +41,43 @@ export default function ClientsList() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/clients/export?format=csv`}>Export CSV</a>
-        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/clients/export?format=json`}>Export JSON</a>
+        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/clients/export?format=csv`}>
+          Export CSV
+        </a>
+        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/clients/export?format=json`}>
+          Export JSON
+        </a>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-left border">
-          <thead>
-            <tr>
-              <th className="px-2">Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            {clients.map((c) => (
-              <tr key={c.id} className="odd:bg-gray-50 hover:bg-gray-100">
-                <td className="px-2">
-                  <a className="text-primary underline" href={c.links?.['ui.self'] || `/clients/${c.id}`}>
-                    {c.first_name} {c.last_name}
-                  </a>
-                </td>
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-200 animate-pulse"></div>
+          ))}
+        </div>
+      ) : clients.length === 0 ? (
+        <div>No clients found.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left border">
+            <thead>
+              <tr>
+                <th className="px-2">Name</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+            </thead>
+            <tbody>
+              {clients.map((c) => (
+                <tr key={c.id} className="odd:bg-gray-50 hover:bg-gray-100">
+                  <td className="px-2">
+                    <a className="text-primary underline" href={c.links?.['ui.self'] || `/clients/${c.id}`}>
+                      {c.first_name} {c.last_name}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Layout>
   );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import Layout from '../components/Layout';
 
 type Summary = {
   total_clients: number;
@@ -38,16 +39,23 @@ export default function Dashboard() {
   }, []);
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8000/ws/dashboard/');
-    ws.onmessage = fetchAll;
-    return () => ws.close();
+    const handler = () => fetchAll();
+    window.addEventListener('ws-message', handler);
+    return () => window.removeEventListener('ws-message', handler);
   }, []);
-
-  if (!summary) return <div className="p-4">Loading...</div>;
+  if (!summary)
+    return (
+      <Layout title="Dashboard">
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-200 animate-pulse"></div>
+          ))}
+        </div>
+      </Layout>
+    );
 
   return (
-    <div className="p-4 space-y-6">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+    <Layout title="Dashboard">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="p-4 bg-primary-50 rounded">
           <div className="text-sm">Clients</div>
@@ -114,6 +122,6 @@ export default function Dashboard() {
           </table>
         </div>
       </div>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/src/pages/TripDetail.tsx
+++ b/frontend/src/pages/TripDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import Layout from '../components/Layout';
 
 type Trip = {
   id: string;
@@ -76,7 +77,16 @@ export default function TripDetail({ id }: { id: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, trip]);
 
-  if (!trip) return <div className="p-4">Loading...</div>;
+  if (!trip)
+    return (
+      <Layout title="Trip">
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-200 animate-pulse"></div>
+          ))}
+        </div>
+      </Layout>
+    );
 
   const seatCount = seats.length > 0 ? Math.max(...seats.map((s) => s.seat_no)) : 0;
   const seatNumbers = Array.from({ length: seatCount }, (_, i) => i + 1);
@@ -120,12 +130,23 @@ export default function TripDetail({ id }: { id: string }) {
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Trip {trip.trip_date} {trip.origin} → {trip.destination}</h1>
-      <div className="flex gap-4 border-b">
-        <button className={`p-2 ${tab === 'detail' ? 'border-b-2' : ''}`} onClick={() => setTab('detail')}>Details</button>
-        <button className={`p-2 ${tab === 'report' ? 'border-b-2' : ''}`} onClick={() => setTab('report')}>Report</button>
-      </div>
+    <Layout
+      title={`Trip ${trip.trip_date} ${trip.origin} → ${trip.destination}`}
+      breadcrumbs={[
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Trips', href: '/trips' },
+        { label: `Trip ${trip.trip_date}` },
+      ]}
+    >
+      <div className="space-y-4">
+        <div className="flex gap-4 border-b">
+          <button className={`p-2 ${tab === 'detail' ? 'border-b-2' : ''}`} onClick={() => setTab('detail')}>
+            Details
+          </button>
+          <button className={`p-2 ${tab === 'report' ? 'border-b-2' : ''}`} onClick={() => setTab('report')}>
+            Report
+          </button>
+        </div>
       {tab === 'detail' ? (
         <div className="space-y-4">
           <div>
@@ -221,6 +242,7 @@ export default function TripDetail({ id }: { id: string }) {
         </div>
       )}
     </div>
+    </Layout>
   );
 }
 

--- a/frontend/src/pages/TripsList.test.tsx
+++ b/frontend/src/pages/TripsList.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../api', () => ({ api: vi.fn(() => Promise.resolve([])) }));
+import { api } from '../api';
+import TripsList from './TripsList';
+
+describe('TripsList filters', () => {
+  it('calls API with filters', async () => {
+    render(<TripsList />);
+    fireEvent.change(screen.getByPlaceholderText('Destination'), { target: { value: 'Paris' } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(api).toHaveBeenCalledWith('/api/trips/?destination=Paris');
+  });
+});

--- a/frontend/src/pages/TripsList.tsx
+++ b/frontend/src/pages/TripsList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../api';
+import Layout from '../components/Layout';
 
 type Trip = {
   id: string;
@@ -14,32 +15,32 @@ export default function TripsList() {
   const [destination, setDestination] = useState('');
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
+  const [loading, setLoading] = useState(false);
 
   const fetchTrips = () => {
+    setLoading(true);
     const params = new URLSearchParams();
     if (destination) params.append('destination', destination);
     if (dateFrom) params.append('date_from', dateFrom);
     if (dateTo) params.append('date_to', dateTo);
-    api<{ trips: Trip[] }>('/api/dashboard/')
-    .then((d) => setTrips(d?.trips ?? []))
-    .catch((err) => {
-      console.error("Failed to fetch trips", err);
-      setTrips([]);
-    });
+    api<Trip[]>(`/api/trips/?${params.toString()}`)
+      .then(setTrips)
+      .catch(() => setTrips([]))
+      .finally(() => setLoading(false));
+  };
 
   useEffect(() => {
     fetchTrips();
   }, [destination, dateFrom, dateTo]);
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:8000/ws/dashboard/');
-    ws.onmessage = fetchTrips;
-    return () => ws.close();
+    const handler = () => fetchTrips();
+    window.addEventListener('ws-message', handler);
+    return () => window.removeEventListener('ws-message', handler);
   }, [destination, dateFrom, dateTo]);
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Trips</h1>
+    <Layout title="Trips" breadcrumbs={[{ label: 'Dashboard', href: '/dashboard' }, { label: 'Trips' }]}>
       <div className="flex flex-col md:flex-row gap-2">
         <input
           className="border p-2 flex-1"
@@ -59,31 +60,47 @@ export default function TripsList() {
           value={dateTo}
           onChange={(e) => setDateTo(e.target.value)}
         />
-        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/trips/export?format=csv`}>Export CSV</a>
-        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/trips/export?format=json`}>Export JSON</a>
+        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/trips/export?format=csv`}>
+          Export CSV
+        </a>
+        <a className="bg-primary text-white px-4 py-2 text-center" href={`/api/trips/export?format=json`}>
+          Export JSON
+        </a>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-left border">
-          <thead>
-            <tr>
-              <th className="px-2">Date</th>
-              <th className="px-2">Destination</th>
-              <th className="px-2"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {trips.map((t) => (
-              <tr key={t.id} className="odd:bg-gray-50 hover:bg-gray-100">
-                <td className="px-2">{t.trip_date}</td>
-                <td className="px-2">{t.destination}</td>
-                <td className="px-2">
-                  <a className="text-primary underline" href={t.links?.['ui.self'] || `/trips/${t.id}`}>View</a>
-                </td>
+      {loading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-4 bg-gray-200 animate-pulse"></div>
+          ))}
+        </div>
+      ) : trips.length === 0 ? (
+        <div>No trips scheduled yet.</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left border">
+            <thead>
+              <tr>
+                <th className="px-2">Date</th>
+                <th className="px-2">Destination</th>
+                <th className="px-2"></th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+            </thead>
+            <tbody>
+              {trips.map((t) => (
+                <tr key={t.id} className="odd:bg-gray-50 hover:bg-gray-100">
+                  <td className="px-2">{t.trip_date}</td>
+                  <td className="px-2">{t.destination}</td>
+                  <td className="px-2">
+                    <a className="text-primary underline" href={t.links?.['ui.self'] || `/trips/${t.id}`}>
+                      View
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- add responsive navbar with websocket live indicator
- standardize page layout with breadcrumbs and toasts
- enable trip and client filters with loading/empty states

## Testing
- `npm --prefix frontend test` *(fails: vitest: not found)*
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b57b7f2bf083308124300105570e41