### PR TITLE
feat: implement design system tokens and themes

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,11 +9,11 @@ interface Crumb {
 
 export default function Layout({ title, breadcrumbs = [], children }: { title: string; breadcrumbs?: Crumb[]; children: ReactNode }) {
   return (
-    <div className="min-h-screen grid grid-rows-[auto,1fr]">
+    <div className="min-h-screen grid grid-rows-[auto,1fr] bg-background text-foreground">
       <Navbar />
       <main className="p-4 max-w-7xl mx-auto w-full space-y-4">
         {breadcrumbs.length > 0 && (
-          <nav className="text-sm text-gray-500">
+          <nav className="text-sm text-foreground/60">
             {breadcrumbs.map((bc, i) => (
               <span key={i}>
                 {bc.href ? (

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,8 @@
-import { Disclosure } from '@headlessui/react';
-import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { useWebSocket } from './WebSocketProvider';
+import { useState } from 'react'
+import { Disclosure } from '@headlessui/react'
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline'
+import { useWebSocket } from './WebSocketProvider'
+import Button from './ui/Button'
 
 const links = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -9,9 +11,24 @@ const links = [
 ];
 
 export default function Navbar() {
-  const { connected } = useWebSocket();
+  const { connected } = useWebSocket()
+  const [dark, setDark] = useState(
+    document.documentElement.classList.contains('dark'),
+  )
+
+  const toggleTheme = () => {
+    const root = document.documentElement
+    if (root.classList.contains('dark')) {
+      root.classList.remove('dark')
+      setDark(false)
+    } else {
+      root.classList.add('dark')
+      setDark(true)
+    }
+  }
+
   return (
-    <Disclosure as="nav" className="bg-primary text-white">
+    <Disclosure as="nav" className="bg-primary text-primary-foreground">
       {({ open }) => (
         <>
           <div className="mx-auto max-w-7xl px-4">
@@ -28,7 +45,14 @@ export default function Navbar() {
                   ))}
                 </div>
               </div>
-              <span className={`h-3 w-3 rounded-full ${connected ? 'bg-success' : 'bg-gray-300'}`}></span>
+              <div className="flex items-center space-x-4">
+                <Button onClick={toggleTheme} variant="stellar">
+                  {dark ? 'Light' : 'Dark'}
+                </Button>
+                <span
+                  className={`h-3 w-3 rounded-full ${connected ? 'bg-success' : 'bg-foreground/30'}`}
+                ></span>
+              </div>
             </div>
           </div>
           <Disclosure.Panel className="sm:hidden px-2 pb-3 space-y-1">
@@ -41,5 +65,5 @@ export default function Navbar() {
         </>
       )}
     </Disclosure>
-  );
+  )
 }

--- a/frontend/src/components/Toasts.tsx
+++ b/frontend/src/components/Toasts.tsx
@@ -8,7 +8,7 @@ function Toast({ id, message }: { id: number; message: string }) {
     return () => clearTimeout(timer);
   }, [id, dismiss]);
   return (
-    <div className="bg-primary text-white px-4 py-2 rounded shadow">
+    <div className="bg-primary text-primary-foreground px-4 py-2 rounded shadow-[var(--shadow-cosmic)]">
       {message}
     </div>
   );

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,16 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+export type ButtonVariant = 'default' | 'stellar' | 'cosmic'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+}
+
+export default function Button({ variant = 'default', className = '', ...props }: ButtonProps) {
+  const variants: Record<ButtonVariant, string> = {
+    default: 'btn',
+    stellar: 'btn btn-stellar',
+    cosmic: 'btn btn-cosmic',
+  }
+  return <button className={`${variants[variant]} ${className}`} {...props} />
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,55 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --primary: 224 76% 15%;
+  --primary-glow: 224 76% 25%;
+  --primary-foreground: 210 40% 98%;
+  --accent: 43 96% 56%;
+  --background: 210 40% 98%;
+  --foreground: 224 71% 4%;
+  --card: 0 0% 100%;
+  --gradient-cosmic: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-glow)));
+  --gradient-stellar: linear-gradient(135deg, hsl(var(--accent)), hsl(43 96% 70%));
+  --shadow-cosmic: 0 10px 40px -10px hsl(var(--primary) / 0.3);
+  --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-bounce: all 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+.dark {
+  --primary: 224 76% 70%;
+  --background: 224 71% 4%;
+  --card: 224 76% 6%;
+  --foreground: 210 40% 98%;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  @apply bg-background text-foreground;
+  transition: var(--transition-smooth);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.btn {
+  @apply inline-flex items-center justify-center px-4 py-2 rounded font-medium text-primary-foreground;
+  background-image: var(--gradient-cosmic);
+  transition: var(--transition-bounce);
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.btn:hover {
+  @apply scale-105;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.btn-stellar {
+  background-image: var(--gradient-stellar);
+  box-shadow: var(--shadow-cosmic);
+}
+
+.btn-cosmic {
+  background-image: var(--gradient-cosmic);
+  border: 1px solid hsl(var(--primary-glow));
+  box-shadow: 0 0 0 1px hsl(var(--primary-glow));
+}
+
+.btn-cosmic:hover {
+  box-shadow: 0 0 10px hsl(var(--primary-glow));
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,15 +1,23 @@
 import type { Config } from 'tailwindcss'
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx,js,jsx,html}'],
   theme: {
     extend: {
       colors: {
-        primary: { DEFAULT: '#155EEF', 600: '#1E3A8A', 50: '#E6EEFF' },
-        accent: { DEFAULT: '#00B3FF' },
-        success: '#22C55E',
-        warning: '#F59E0B',
-        danger: '#EF4444',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: 'hsl(var(--card))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          glow: 'hsl(var(--primary-glow))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        accent: 'hsl(var(--accent))',
+        success: 'hsl(142 72% 29%)',
+        warning: 'hsl(38 92% 50%)',
+        danger: 'hsl(0 84% 60%)',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add HSL-driven design tokens and dark/light theming
- introduce reusable Button component with cosmic and stellar variants
- apply new tokens to navbar, layout, and toast notifications

## Testing
- `npm test` (fails: ReferenceError: expect is not defined)
- `npm run lint` (fails: 8 errors, 6 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b82731f7e483309f7fc72588b0500c